### PR TITLE
Fix #16

### DIFF
--- a/OpenInvoicePeru/OpenInvoicePeru.ApiClientCSharp/Program.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.ApiClientCSharp/Program.cs
@@ -8,28 +8,40 @@ namespace OpenInvoicePeru.ApiClientCSharp
 {
     class Program
     {
-        private static readonly string _baseUrl = "http://localhost:50888/OpenInvoicePeru/api";
+        private static readonly string BaseUrl = "http://localhost:50888/OpenInvoicePeru/api";
+        private static readonly string UrlSunat = "https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService";
 
-        static void Main(string[] args)
+        static void Main()
         {
             Console.WriteLine("Prueba de API REST de OpenInvoicePeru (C#)");
+            CrearFactura();
+            CrearResumenDiario();
+        }
 
+        private static Contribuyente CrearEmisor()
+        {
+            return new Contribuyente
+            {
+                NroDocumento = "20100070970",
+                TipoDocumento = "6",
+                Direccion = "CAL.MORELLI NRO. 181 INT. P-2",
+                Urbanizacion = "-",
+                Departamento = "LIMA",
+                Provincia = "LIMA",
+                Distrito = "SAN BORJA",
+                NombreComercial = "PLAZA VEA",
+                NombreLegal = "SUPERMERCADOS PERUANOS SOCIEDAD ANONIMA"
+            };
+        }
+
+        private static void CrearFactura()
+        {
             try
             {
+                Console.WriteLine("Ejemplo Factura");
                 var documento = new DocumentoElectronico
                 {
-                    Emisor = new Contribuyente
-                    {
-                        NroDocumento = "20100070970",
-                        TipoDocumento = "6",
-                        Direccion = "CAL.MORELLI NRO. 181 INT. P-2",
-                        Urbanizacion = "-",
-                        Departamento = "LIMA",
-                        Provincia = "LIMA",
-                        Distrito = "SAN BORJA",
-                        NombreComercial = "PLAZA VEA",
-                        NombreLegal = "SUPERMERCADOS PERUANOS SOCIEDAD ANONIMA"
-                    },
+                    Emisor = CrearEmisor(),
                     Receptor = new Contribuyente
                     {
                         NroDocumento = "20100039207",
@@ -47,7 +59,7 @@ namespace OpenInvoicePeru.ApiClientCSharp
                     TotalIgv = 18,
                     TotalVenta = 118,
                     Gravadas = 100,
-                    Items = new List<DetalleDocumento>()
+                    Items = new List<DetalleDocumento>
                     {
                         new DetalleDocumento
                         {
@@ -69,7 +81,7 @@ namespace OpenInvoicePeru.ApiClientCSharp
 
                 Console.WriteLine("Generando XML....");
 
-                var client = new RestClient(_baseUrl);
+                var client = new RestClient(BaseUrl);
 
                 var requestInvoice = new RestRequest("GenerarFactura", Method.POST)
                 {
@@ -115,7 +127,7 @@ namespace OpenInvoicePeru.ApiClientCSharp
                     Ruc = documento.Emisor.NroDocumento,
                     UsuarioSol = "MODDATOS",
                     ClaveSol = "MODDATOS",
-                    EndPointUrl = "https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService",
+                    EndPointUrl = UrlSunat,
                     IdDocumento = documento.IdDocumento,
                     TipoDocumento = documento.TipoDocumento,
                     TramaXmlFirmado = responseFirma.Data.TramaXmlFirmado
@@ -145,7 +157,122 @@ namespace OpenInvoicePeru.ApiClientCSharp
             {
                 Console.ReadLine();
             }
+        }
 
+        private static void CrearResumenDiario()
+        {
+            try
+            {
+                Console.WriteLine("Ejemplo de Resumen Diario");
+                var documentoResumenDiario = new ResumenDiario
+                {
+                    IdDocumento = string.Format("RC-{0:yyyyMMdd}-001", DateTime.Today),
+                    FechaEmision = DateTime.Today.ToString("yyyy-MM-dd"),
+                    FechaReferencia = DateTime.Today.AddDays(-1).ToString("yyyy-MM-dd"),
+                    Emisor = CrearEmisor(),
+                    Resumenes = new List<GrupoResumen>()
+                };
+
+                documentoResumenDiario.Resumenes.Add(new GrupoResumen
+                {
+                    Id = 1,
+                    CorrelativoInicio = 33386,
+                    CorrelativoFin = 33390,
+                    Moneda = "PEN",
+                    TotalVenta = 190.9m,
+                    TotalIgv = 29.12m,
+                    Gravadas = 161.78m,
+                    Exoneradas = 0,
+                    Exportacion = 0,
+                    TipoDocumento = "03",
+                    Serie = "BB50"
+                });
+                documentoResumenDiario.Resumenes.Add(new GrupoResumen
+                {
+                    Id = 2,
+                    CorrelativoInicio = 40000,
+                    CorrelativoFin = 40500,
+                    Moneda = "PEN",
+                    TotalVenta = 9580m,
+                    TotalIgv = 1411.36m,
+                    Gravadas = 8168.64m,
+                    Exoneradas = 0,
+                    Exportacion = 0,
+                    TipoDocumento = "03",
+                    Serie = "BB30"
+                });
+
+
+                Console.WriteLine("Generando XML....");
+                var client = new RestClient(BaseUrl);
+                var requestInvoice = new RestRequest("GenerarResumenDiario", Method.POST)
+                {
+                    RequestFormat = DataFormat.Json
+                };
+                requestInvoice.AddBody(documentoResumenDiario);
+                var documentoResponse = client.Execute<DocumentoResponse>(requestInvoice);
+                if (!documentoResponse.Data.Exito)
+                {
+                    throw new ApplicationException(documentoResponse.Data.MensajeError);
+                }
+                Console.WriteLine("Firmando XML...");
+                // Firmado del Documento.
+                var firmado = new FirmadoRequest
+                {
+                    TramaXmlSinFirma = documentoResponse.Data.TramaXmlSinFirma,
+                    CertificadoDigital = Convert.ToBase64String(File.ReadAllBytes("Certificado.pfx")),
+                    PasswordCertificado = string.Empty,
+                    UnSoloNodoExtension = true
+                };
+
+                var requestFirma = new RestRequest("Firmar", Method.POST) { RequestFormat = DataFormat.Json };
+                requestFirma.AddBody(firmado);
+
+                var responseFirma = client.Execute<FirmadoResponse>(requestFirma);
+
+                if (!responseFirma.Data.Exito)
+                {
+                    throw new ApplicationException(responseFirma.Data.MensajeError);
+                }
+
+                Console.WriteLine("Enviando a SUNAT....");
+
+                var sendBill = new EnviarDocumentoRequest
+                {
+                    Ruc = documentoResumenDiario.Emisor.NroDocumento,
+                    UsuarioSol = "MODDATOS",
+                    ClaveSol = "MODDATOS",
+                    EndPointUrl = UrlSunat,
+                    IdDocumento = documentoResumenDiario.IdDocumento,
+                    TramaXmlFirmado = responseFirma.Data.TramaXmlFirmado
+                };
+
+                var requestSendBill = new RestRequest("EnviarResumen", Method.POST) { RequestFormat = DataFormat.Json };
+
+                requestSendBill.AddBody(sendBill);
+
+                var responseSendBill = client.Execute<EnviarDocumentoResponse>(requestSendBill);
+
+                if (!responseSendBill.Data.Exito)
+                {
+                    throw new ApplicationException(responseSendBill.Data.MensajeError);
+                }
+                File.WriteAllBytes(string.Format(".\\{0}.xml", responseSendBill.Data.NombreArchivo), Convert.FromBase64String(responseFirma.Data.TramaXmlFirmado));
+
+                File.WriteAllBytes(string.Format(".\\R-{0}.zip", responseSendBill.Data.NombreArchivo), Convert.FromBase64String(responseSendBill.Data.TramaZipCdr));
+
+
+                Console.WriteLine("Respuesta de SUNAT:");
+                Console.WriteLine(responseSendBill.Data.MensajeRespuesta);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+            finally
+            {
+                Console.ReadLine();
+            }
         }
     }
 }

--- a/OpenInvoicePeru/OpenInvoicePeru.ApiClientVisualBasic/Program.vb
+++ b/OpenInvoicePeru/OpenInvoicePeru.ApiClientVisualBasic/Program.vb
@@ -6,14 +6,11 @@ Imports RestSharp
 
 Module Program
 
-    Private ReadOnly BaseUrl As String = "http://localhost:50888/OpenInvoicePeru/api"
+    Private ReadOnly _baseUrl As String = "http://localhost:50888/OpenInvoicePeru/api"
+    Private ReadOnly _urlSunat As String = "https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService"
 
-    Sub Main(args As String())
-        Console.WriteLine("Prueba de API REST de OpenInvoicePeru (Visual Basic)")
-
-        Try
-            Dim documento As New DocumentoElectronico() With {
-                        .Emisor = New Contribuyente() With {
+    Private Function CrearEmisor() As Contribuyente
+        Return New Contribuyente() With {
                             .NroDocumento = "20100070970",
                             .TipoDocumento = "6",
                             .Direccion = "CAL.MORELLI NRO. 181 INT. P-2",
@@ -22,44 +19,57 @@ Module Program
                             .Provincia = "LIMA",
                             .Distrito = "SAN BORJA",
                             .NombreComercial = "PLAZA VEA",
-                            .NombreLegal = "SUPERMERCADOS PERUANOS SOCIEDAD ANONIMA"
-                        },
-                        .Receptor = New Contribuyente() With {
-                            .NroDocumento = "20100039207",
-                            .TipoDocumento = "6",
-                            .NombreLegal = "RANSA COMERCIAL S.A."
-                        },
-                        .IdDocumento = "FF11-002",
-                        .FechaEmision = Date.Today.AddDays(-5).ToString("yyyy-MM-dd"),
-                        .Moneda = "PEN",
-                        .MontoEnLetras = "SON CIENTO DIECIOCHO SOLES CON 0/100",
-                        .CalculoIgv = 0.18D,
-                        .CalculoIsc = 0.1D,
-                        .CalculoDetraccion = 0.04D,
-                        .TipoDocumento = "01",
-                        .TotalIgv = 18,
-                        .TotalVenta = 118,
-                        .Gravadas = 100,
-                        .Items = New List(Of DetalleDocumento)()
+                            .NombreLegal = "SUPERMERCADOS PERUANOS SOCIEDAD ANONIMA"}
+    End Function
+
+    Sub Main(args As String())
+        Console.WriteLine("Prueba de API REST de OpenInvoicePeru (Visual Basic)")
+        CrearFactura()
+        CrearResumenDiario()
+    End Sub
+
+    Private Sub CrearFactura()
+
+        Try
+            Console.WriteLine("Ejemplo Factura")
+            Dim documento As New DocumentoElectronico() With {
+                    .Emisor = CrearEmisor(),
+                    .Receptor = New Contribuyente() With {
+                    .NroDocumento = "20100039207",
+                    .TipoDocumento = "6",
+                    .NombreLegal = "RANSA COMERCIAL S.A."
+                    },
+                    .IdDocumento = "FF11-002",
+                    .FechaEmision = Date.Today.AddDays(-5).ToString("yyyy-MM-dd"),
+                    .Moneda = "PEN",
+                    .MontoEnLetras = "SON CIENTO DIECIOCHO SOLES CON 0/100",
+                    .CalculoIgv = 0.18D,
+                    .CalculoIsc = 0.1D,
+                    .CalculoDetraccion = 0.04D,
+                    .TipoDocumento = "01",
+                    .TotalIgv = 18,
+                    .TotalVenta = 118,
+                    .Gravadas = 100,
+                    .Items = New List(Of DetalleDocumento)()
                     }
 
             documento.Items.Add(New DetalleDocumento() With {
-                        .Id = 1,
-                        .Cantidad = 5,
-                        .PrecioReferencial = 20,
-                        .PrecioUnitario = 20,
-                        .TipoPrecio = "01",
-                        .CodigoItem = "1234234",
-                        .Descripcion = "Arroz Costeño",
-                        .UnidadMedida = "KG",
-                        .Impuesto = 18,
-                        .TipoImpuesto = "10",
-                        .TotalVenta = 100,
-                        .Suma = 100
-                    })
+                                   .Id = 1,
+                                   .Cantidad = 5,
+                                   .PrecioReferencial = 20,
+                                   .PrecioUnitario = 20,
+                                   .TipoPrecio = "01",
+                                   .CodigoItem = "1234234",
+                                   .Descripcion = "Arroz Costeño",
+                                   .UnidadMedida = "KG",
+                                   .Impuesto = 18,
+                                   .TipoImpuesto = "10",
+                                   .TotalVenta = 100,
+                                   .Suma = 100
+                                   })
 
             Console.WriteLine("Generando XML....")
-            Dim client As New RestClient(BaseUrl)
+            Dim client As New RestClient(_baseUrl)
 
             Dim requestInvoice As New RestRequest("GenerarFactura", Method.POST)
             requestInvoice.RequestFormat = DataFormat.Json
@@ -75,15 +85,15 @@ Module Program
             Console.WriteLine("Firmando XML...")
             ' Firmado del Documento.
             Dim firmado As New FirmadoRequest() With {
-                .TramaXmlSinFirma = documentoResponse.Data.TramaXmlSinFirma,
-                .CertificadoDigital = Convert.ToBase64String(File.ReadAllBytes("certificado.pfx")),
-                .PasswordCertificado = String.Empty,
-                .UnSoloNodoExtension = False
-            }
+                    .TramaXmlSinFirma = documentoResponse.Data.TramaXmlSinFirma,
+                    .CertificadoDigital = Convert.ToBase64String(File.ReadAllBytes("certificado.pfx")),
+                    .PasswordCertificado = String.Empty,
+                    .UnSoloNodoExtension = False
+                    }
 
             Dim requestFirma As New RestRequest("Firmar", Method.POST) With {
-                .RequestFormat = DataFormat.Json
-            }
+                    .RequestFormat = DataFormat.Json
+                    }
             requestFirma.AddBody(firmado)
 
             Dim responseFirma = client.Execute(Of FirmadoResponse)(requestFirma)
@@ -95,18 +105,18 @@ Module Program
             Console.WriteLine("Enviando a SUNAT....")
 
             Dim sendBill As New EnviarDocumentoRequest() With {
-                .Ruc = documento.Emisor.NroDocumento,
-                .UsuarioSol = "MODDATOS",
-                .ClaveSol = "MODDATOS",
-                .EndPointUrl = "https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService",
-                .IdDocumento = documento.IdDocumento,
-                .TipoDocumento = documento.TipoDocumento,
-                .TramaXmlFirmado = responseFirma.Data.TramaXmlFirmado
-            }
+                    .Ruc = documento.Emisor.NroDocumento,
+                    .UsuarioSol = "MODDATOS",
+                    .ClaveSol = "MODDATOS",
+                    .EndPointUrl = _urlSunat,
+                    .IdDocumento = documento.IdDocumento,
+                    .TipoDocumento = documento.TipoDocumento,
+                    .TramaXmlFirmado = responseFirma.Data.TramaXmlFirmado
+                    }
 
             Dim requestSendBill As New RestRequest("EnviarDocumento", Method.POST) With {
-                .RequestFormat = DataFormat.Json
-            }
+                    .RequestFormat = DataFormat.Json
+                    }
             requestSendBill.AddBody(sendBill)
 
             Dim responseSendBill = client.Execute(Of EnviarDocumentoResponse)(requestSendBill)
@@ -122,7 +132,113 @@ Module Program
         Finally
             Console.ReadLine()
         End Try
-
     End Sub
+
+    Private Sub CrearResumenDiario()
+        Try
+            Console.WriteLine("Ejemplo de Resumen Diario")
+            Dim documentoResumenDiario As New ResumenDiario() With {
+                .IdDocumento = String.Format("RC-{0:yyyyMMdd}-001", Date.Today),
+                .FechaEmision = Date.Today.ToString("yyyy-MM-dd"),
+                .FechaReferencia = Date.Today.AddDays(-1).ToString("yyyy-MM-dd"),
+                .Emisor = CrearEmisor(),
+                .Resumenes = New List(Of GrupoResumen)
+            }
+
+            documentoResumenDiario.Resumenes.Add(New GrupoResumen() With {
+                .Id = 1,
+                .CorrelativoInicio = 33386,
+                .CorrelativoFin = 33390,
+                .Moneda = "PEN",
+                .TotalVenta = 190.9D,
+                .TotalIgv = 29.12D,
+                .Gravadas = 161.78D,
+                .Exoneradas = 0,
+                .Exportacion = 0,
+                .TipoDocumento = "03",
+                .Serie = "BB50"})
+            documentoResumenDiario.Resumenes.Add(New GrupoResumen() With {
+                .Id = 2,
+                .CorrelativoInicio = 40000,
+                .CorrelativoFin = 40500,
+                .Moneda = "PEN",
+                .TotalVenta = 9580D,
+                .TotalIgv = 1411.36D,
+                .Gravadas = 8168.64D,
+                .Exoneradas = 0,
+                .Exportacion = 0,
+                .TipoDocumento = "03",
+                .Serie = "BB30"})
+
+
+            Console.WriteLine("Generando XML....")
+            Dim client As New RestClient(_baseUrl)
+            Dim requestInvoice As New RestRequest("GenerarResumenDiario", Method.POST)
+            requestInvoice.RequestFormat = DataFormat.Json
+            requestInvoice.AddBody(documentoResumenDiario)
+            Dim documentoResponse = client.Execute(Of DocumentoResponse)(requestInvoice)
+            If Not documentoResponse.Data.Exito Then
+                Throw New ApplicationException(documentoResponse.Data.MensajeError)
+            End If
+            Console.WriteLine("Firmando XML...")
+            ' Firmado del Documento.
+            Dim firmado As New FirmadoRequest() With {
+                .TramaXmlSinFirma = documentoResponse.Data.TramaXmlSinFirma,
+                .CertificadoDigital = Convert.ToBase64String(File.ReadAllBytes("Certificado.pfx")),
+                .PasswordCertificado = String.Empty,
+                .UnSoloNodoExtension = True
+            }
+
+            Dim requestFirma As New RestRequest("Firmar", Method.POST) With {
+            .RequestFormat = DataFormat.Json}
+            requestFirma.AddBody(firmado)
+
+            Dim responseFirma = client.Execute(Of FirmadoResponse)(requestFirma)
+
+            If Not responseFirma.Data.Exito Then
+                Throw New ApplicationException(responseFirma.Data.MensajeError)
+            End If
+
+            Console.WriteLine("Enviando a SUNAT....")
+
+            Dim sendBill As New EnviarDocumentoRequest() With {
+                .Ruc = documentoResumenDiario.Emisor.NroDocumento,
+                .UsuarioSol = "MODDATOS",
+                .ClaveSol = "MODDATOS",
+                .EndPointUrl = _urlSunat,
+                .IdDocumento = documentoResumenDiario.IdDocumento,
+                .TramaXmlFirmado = responseFirma.Data.TramaXmlFirmado
+            }
+
+            Dim requestSendBill As New RestRequest("EnviarResumen", Method.POST) With {
+                .RequestFormat = DataFormat.Json
+            }
+
+            requestSendBill.AddBody(sendBill)
+
+            Dim responseSendBill = client.Execute(Of EnviarDocumentoResponse)(requestSendBill)
+
+            If Not responseSendBill.Data.Exito Then
+                Throw New ApplicationException(responseSendBill.Data.MensajeError)
+            Else
+                File.WriteAllBytes(String.Format(".\{0}.xml",
+                                             responseSendBill.Data.NombreArchivo),
+                               Convert.FromBase64String(responseFirma.Data.TramaXmlFirmado))
+
+                File.WriteAllBytes(String.Format(".\R-{0}.zip",
+                                             responseSendBill.Data.NombreArchivo),
+                               Convert.FromBase64String(responseSendBill.Data.TramaZipCdr))
+            End If
+
+
+            Console.WriteLine("Respuesta de SUNAT:")
+            Console.WriteLine(responseSendBill.Data.MensajeRespuesta)
+        Catch ex As Exception
+            Console.WriteLine(ex.Message)
+        Finally
+            Console.ReadLine()
+        End Try
+    End Sub
+
 
 End Module

--- a/OpenInvoicePeru/OpenInvoicePeru.WebApi/Controllers/EnviarResumenController.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.WebApi/Controllers/EnviarResumenController.cs
@@ -11,7 +11,7 @@ namespace OpenInvoicePeru.WebApi.Controllers
         {
             var response = new EnviarResumenResponse();
             var serializador = new Serializador();
-            var nombreArchivo = $"{request.Ruc}-{request.TipoDocumento}-{request.IdDocumento}";
+            var nombreArchivo = $"{request.Ruc}-{request.IdDocumento}";
 
             try
             {


### PR DESCRIPTION
Fix #14
La clase EnviarResumenRequest no existe, debido a que la clase EnviarDocumentoRequest es la que se recibe como parámetro en el metodo EnviarResumen de la API REST. Sin embargo se corrige parámetro redundante de TipoDocumento.